### PR TITLE
Remove Duplication of Repo Proofs

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -935,7 +935,7 @@ func (env *Env) populateTestProofRow() {
 
 	err = env.ds.Store(datastore.Proof{
 		EntryType:      "proof",
-		UserSubmitted:  "jduboiTEST@csumb.edu",
+		UserSubmitted:  "bkondo@csumb.edu",
 		ProofName:      "Repository - Code Test",
 		ProofType:      "prop",
 		Premise:        []string{"P", "P → Q", "Q → R", "R → S"},
@@ -955,7 +955,7 @@ func (env *Env) populateTestProofRow() {
 
 	err = env.ds.Store(datastore.Proof{
 		EntryType:      "proof",
-		UserSubmitted:  "jduboisTEST@csumb.edu",
+		UserSubmitted:  "bkondo@csumb.edu",
 		ProofName:      "Repository - Code Test",
 		ProofType:      "prop",
 		Premise:        []string{"P", "P → Q", "Q → R", "R → S"},
@@ -970,7 +970,7 @@ func (env *Env) populateTestProofRow() {
 
 	err = env.ds.Store(datastore.Proof{
 		EntryType:      "argument",
-		UserSubmitted:  "bkondo@csumb.edu",
+		UserSubmitted:  "elarson@csumb.edu",
 		ProofName:      "Repository - Code Test 2",
 		ProofType:      "prop",
 		Premise:        []string{"P", "P → Q", "Q → R"},
@@ -985,7 +985,7 @@ func (env *Env) populateTestProofRow() {
 
 	err = env.ds.Store(datastore.Proof{
 		EntryType:      "proof",
-		UserSubmitted:  "jduboisTEST@csumb.edu",
+		UserSubmitted:  "bkondo@csumb.edu",
 		ProofName:      "Repository - Code Test 2",
 		ProofType:      "prop",
 		Premise:        []string{"P", "P → Q", "Q → R"},

--- a/backend/datastore/datastore.go
+++ b/backend/datastore/datastore.go
@@ -174,29 +174,27 @@ func (p *ProofStore) GetRepoProofs(user UserWithEmail) (error, []SectionProofs) 
    var sectionAssignments []Assignment
    var assignmentProofs []Proof
    for _,section:= range sections {
-      sectionAssignments = nil
-      // assignmentProofs = nil
-      // sectionProofList = nil
+      // sectionAssignments = []Assignment{}
+      assignmentProofs = []Proof{}
+      sectionProofList.ProofList = []Proof{}
       sectionProofList.SectionName = section.Name
-
-      // rows, err := stmt.Query(section.Name)
-      // if err != nil {
-      //    return err, nil
-      // }
-      // defer rows.Close()
-
-      // _,sectionProofList.ProofList = getProofsFromRows(rows)
-      // repoList = append(repoList, sectionProofList)
+      log.Println("-----")
+      log.Println("assignmentProofs at start of section: ", sectionProofList.SectionName)
+      log.Println("  ", len(assignmentProofs), "arguments held")
 
       sectionAssignments, err = p.GetAssignmentsBySection(section.Name)
-      if err == nil {
+      if err == nil { // if no errors occured
          for _,assignment := range sectionAssignments {
             if assignment.Visibility == "true" {
                assignmentProofs, err = p.GetAssignmentProofs(assignment)
+               log.Println("  ", len(assignmentProofs), " assignmentProofs for section: ", sectionProofList.SectionName)
                sectionProofList.ProofList = append(sectionProofList.ProofList, assignmentProofs...)
+               log.Println("  sectionProofList gen info:")
+               log.Println("    ", sectionProofList.SectionName,": ", len(sectionProofList.ProofList), " arguments")
             }
          }
          repoList = append(repoList, sectionProofList)
+         log.Println("  repoList has ", len(repoList), " section assignments list")
       }
    }
 
@@ -958,18 +956,20 @@ func (p *ProofStore) getSection(name string) (*Section, error) {
 func (p *ProofStore) PopulateTestUsersSectionsRosters() {
 	fmt.Println("\n========INSERT USER RECORDS========")
 	userInfo := []User{
-		{Email: "psmithTEST@csumb.edu", FirstName: "Paul", LastName: "Smith", Admin: 1},
-		{Email: "rmarksTEST@csumb.edu", FirstName: "Ryan", LastName: "Marks", Admin: 0},
-		{Email: "lramirezTEST@csumb.edu", FirstName: "LeAnne", LastName: "Ramirez", Admin: 0}, 
-		{Email: "abookerTEST@csumb.edu", FirstName: "Annette", LastName: "Booker", Admin: 1}, 
-		{Email: "mpotterTEST@csumb.edu", FirstName: "Maxwell", LastName: "Potter", Admin: 0}, 
-		{Email: "jduboisTEST@csumb.edu", FirstName: "Jeanne", LastName: "Dubois", Admin: 0}, 
-      {Email: "jdoeTEST@csumb.edu", FirstName: "John", LastName: "Doe", Admin: 0}, 
-      {Email: "sadamsTEST@csumb.edu", FirstName: "Steven", LastName: "Adams", Admin: 0}, 
-		{Email: "gsloneTEST@csumb.edu", FirstName: "Garrett", LastName: "Slone", Admin: 1}, 
-		{Email: "t1deleteTEST@csumb.edu", FirstName: "t1", LastName: "delete1", Admin: 0}, 
-		{Email: "t2deleteTEST@csumb.edu", FirstName: "t2", LastName: "delete2", Admin: 0}, 
-		{Email: "t3deleteTEST@csumb.edu", FirstName: "t3", LastName: "delete3", Admin: 1},
+		// {Email: "psmithTEST@csumb.edu", FirstName: "Paul", LastName: "Smith", Admin: 1},
+		// {Email: "rmarksTEST@csumb.edu", FirstName: "Ryan", LastName: "Marks", Admin: 0},
+		// {Email: "lramirezTEST@csumb.edu", FirstName: "LeAnne", LastName: "Ramirez", Admin: 0}, 
+		// {Email: "abookerTEST@csumb.edu", FirstName: "Annette", LastName: "Booker", Admin: 1}, 
+		// {Email: "mpotterTEST@csumb.edu", FirstName: "Maxwell", LastName: "Potter", Admin: 0}, 
+		// {Email: "jduboisTEST@csumb.edu", FirstName: "Jeanne", LastName: "Dubois", Admin: 0}, 
+      // {Email: "jdoeTEST@csumb.edu", FirstName: "John", LastName: "Doe", Admin: 0}, 
+      // {Email: "sadamsTEST@csumb.edu", FirstName: "Steven", LastName: "Adams", Admin: 0}, 
+		// {Email: "gsloneTEST@csumb.edu", FirstName: "Garrett", LastName: "Slone", Admin: 1}, 
+		// {Email: "t1deleteTEST@csumb.edu", FirstName: "t1", LastName: "delete1", Admin: 0}, 
+		// {Email: "t2deleteTEST@csumb.edu", FirstName: "t2", LastName: "delete2", Admin: 0}, 
+		// {Email: "t3deleteTEST@csumb.edu", FirstName: "t3", LastName: "delete3", Admin: 1},
+      {Email: "elarson@csumb.edu", FirstName: "Emma", LastName: "Larson", Admin: 1},
+      {Email: "bkondo@csumb.edu", FirstName: "Barbara", LastName: "Kondo", Admin: 1},
       {Email: "mkammerer@csumb.edu", FirstName: "Michael", LastName: "Kammerer", Admin: 1},
       {Email: "jasbaker@csumb.edu", FirstName: "Jason", LastName: "Baker", Admin: 1},
 	}
@@ -1014,77 +1014,76 @@ func (p *ProofStore) PopulateTestUsersSectionsRosters() {
          UserEmail: "jasbaker@csumb.edu",
          Role: "instructor",
       },
-      {
-         SectionName: "Baker Section",
-         UserEmail: "gsloneTEST@csumb.edu",
-         Role: "ta",
-      },
+      // {
+      //    SectionName: "Baker Section",
+      //    UserEmail: "gsloneTEST@csumb.edu",
+      //    Role: "ta",
+      // },
       {
          SectionName: "Baker Section",
          UserEmail: "elarson@csumb.edu",
          Role: "student",
       },
-	  {
-		SectionName: "Kondo Section",
-		UserEmail: "bkondo@csumb.edu",
-		Role: "instructor",
-	 },
-	 {
-		SectionName: "Kondo Section",
-		UserEmail: "mkammerer@csumb.edu",
-		Role: "student",
-	 },
-	 {
-		SectionName: "Kondo Section",
-		UserEmail: "t1deleteTEST@csumb.edu",
-		Role: "ta",
-	 },
-	 {
-		SectionName: "Kondo Section",
-		UserEmail: "elarson@csumb.edu",
-		Role: "student",
-	 },
-    {
-		SectionName: "Kammerer Section",
-		UserEmail: "mkammerer@csumb.edu",
-		Role: "instructor",
-	 },
-    {
-		SectionName: "Kammerer Section",
-		UserEmail: "psmithTEST@csumb.edu",
-		Role: "ta",
-	 },
-    {
-		SectionName: "Kammerer Section",
-		UserEmail: "bkondo@csumb.edu",
-		Role: "student",
-	 },
-    
-    {
-		SectionName: "Kammerer Section",
-		UserEmail: "lramirezTEST@csumb.edu",
-		Role: "student",
-	 },
-    {
-		SectionName: "Larson Section",
-		UserEmail: "elarson@csumb.edu",
-		Role: "instructor",
-	 },
-    {
-		SectionName: "Kammerer Section",
-		UserEmail: "abookerTEST@csumb.edu",
-		Role: "ta",
-	 },
-    {
-		SectionName: "Larson Section",
-		UserEmail: "bkondo@csumb.edu",
-		Role: "student",
-	 },
-    {
-		SectionName: "Larson Section",
-		UserEmail: "jduboisTEST@csumb.edu",
-		Role: "student",
-	 },
+      {
+         SectionName: "Kondo Section",
+         UserEmail: "bkondo@csumb.edu",
+         Role: "instructor",
+      },
+      {
+         SectionName: "Kondo Section",
+         UserEmail: "mkammerer@csumb.edu",
+         Role: "student",
+      },
+      // {
+      //    SectionName: "Kondo Section",
+      //    UserEmail: "t1deleteTEST@csumb.edu",
+      //    Role: "ta",
+      // },
+      {
+         SectionName: "Kondo Section",
+         UserEmail: "elarson@csumb.edu",
+         Role: "student",
+      },
+      {
+         SectionName: "Kammerer Section",
+         UserEmail: "mkammerer@csumb.edu",
+         Role: "instructor",
+      },
+      // {
+      //    SectionName: "Kammerer Section",
+      //    UserEmail: "psmithTEST@csumb.edu",
+      //    Role: "ta",
+      // },
+      {
+         SectionName: "Kammerer Section",
+         UserEmail: "bkondo@csumb.edu",
+         Role: "student",
+      },
+      // {
+      //    SectionName: "Kammerer Section",
+      //    UserEmail: "lramirezTEST@csumb.edu",
+      //    Role: "student",
+      // },
+      {
+         SectionName: "Larson Section",
+         UserEmail: "elarson@csumb.edu",
+         Role: "instructor",
+      },
+      // {
+      //    SectionName: "Kammerer Section",
+      //    UserEmail: "abookerTEST@csumb.edu",
+      //    Role: "ta",
+      // },
+      {
+         SectionName: "Larson Section",
+         UserEmail: "bkondo@csumb.edu",
+         Role: "student",
+      },
+      // {
+      //    SectionName: "Larson Section",
+      //    UserEmail: "jduboisTEST@csumb.edu",
+      //    Role: "student",
+      // },
    }
 	fmt.Println("\n========INSERT ROSTER RECORDS========")
 	for _,v := range rosterInfo {

--- a/backend/datastore/sqlite.go
+++ b/backend/datastore/sqlite.go
@@ -131,7 +131,7 @@ func createTables(db *sql.DB) (error) {
 	}
 	
 	// proofs : Unique index on (userSubmitted, proofName, proofCompleted)
-	_, err = db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_user_proof
+	_, err = db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS index_user_proof
 			ON proof (userSubmitted, proofName, proofCompleted)`)
 	if err != nil {
 		return err

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -10,6 +10,7 @@ const repositoryData = {
 
 let adminUsers = [];
 
+//Test comment 1
 /**
  * This function is called by the Google Sign-in Button
  * @param {*} googleUser 

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -845,7 +845,7 @@ function loadRepoProofs() {
                elem.appendChild(
                   new Option(proof.ProofName, proof.Id)
                );
-		    temp.appendChild(proof);
+		    temp.push(proof);
             });
          }
 		 repositoryData.repoProofs = temp;

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1011,31 +1011,13 @@ $(document).ready(function() {
 
       // get the proof from the repository (== means '3' is equal to 3)
       let selectedDataSet = repositoryData[selectedDataSetName];
-      let selectedProof = selectedDataSet.filter( section => {if(section.ProofList != null){return section.ProofList.filter(proof => proof.Id  == selectedDataId );}});
+      let selectedProof = selectedDataSet.filter( proof => proof.Id == selectedDataId );
       if (!selectedProof || selectedProof.length < 1) {
 	 console.error("Selected proof ID not found.");
 	 return;
       }
 
-      let sectionIndex = 0;
-      for(var i = 0; i < selectedDataSet.length; i++) {
-         if(selectedDataSet[i].ProofList != null) {
-            if(selectedDataSet[i].ProofList.filter(proof => proof.Id == selectedDataId)) {
-               sectionIndex = i;
-               break;
-            }
-         }
-      }
-      selectedProof = selectedProof[sectionIndex].ProofList;
-
-      let index = 0;
-      for(var i = 0; i < selectedProof.length; i++) {
-         if(selectedProof[i].Id == selectedDataId) {
-            index = i;
-            break;
-         }
-      }
-      selectedProof = selectedProof[index];
+      selectedProof = selectedProof[0];
       console.log('selected proof', selectedProof);
 
       // set repoProblem if proof originally loaded from the repository select

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -819,7 +819,8 @@ function loadRepoProofs() {
    backendPOST('proofs', { selection: 'repo' }).then(
       (data) => {
 	 console.log("loadRepoProofs", data);
-	 repositoryData.repoProofs = data;
+	 //repositoryData.repoProofs = data;
+	      let temp = [];
 
 	 //prepareSelect('#repoProofSelect', data);
 	 let elem = document.querySelector('#repoProofSelect');
@@ -844,8 +845,10 @@ function loadRepoProofs() {
                elem.appendChild(
                   new Option(proof.ProofName, proof.Id)
                );
+		    temp.appendChild(proof);
             });
          }
+		 repositoryData.repoProofs = temp;
 	 });
 
 	 // Make section headers not selectable

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -10,7 +10,6 @@ const repositoryData = {
 
 let adminUsers = [];
 
-//Test comment 1
 /**
  * This function is called by the Google Sign-in Button
  * @param {*} googleUser 


### PR DESCRIPTION
When the Repository proofs are loaded into the selector, they are no longer duplicated across multiple classes.
NOTE: This was mainly an admin-side issue since students would most-likely only be in one class.